### PR TITLE
feat: ajust nodejsscan

### DIFF
--- a/.github/workflows/sast.yaml
+++ b/.github/workflows/sast.yaml
@@ -18,7 +18,16 @@ jobs:
       - name: Configurar o Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.11"
+
+      - name: Instalar dependências de build
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential
+
+      - name: Atualizar pip e ferramentas de build
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
 
       - name: Instalar nodejsscan
         run: pip install --upgrade njsscan


### PR DESCRIPTION
O workflow foi criado com uma configuração incompleta que não atendia aos requisitos de compilação do `pydantic-core` (dependência do `nodejsscan`). Os problemas identificados foram:

1. **Versão genérica do Python**: O uso de `python-version: "3.x"` permitia que o GitHub Actions escolhesse uma versão incompatível (como Python 3.12), que tem problemas conhecidos com `pydantic-core`.
2. **Falta de dependências de build**: O `pydantic-core` é um pacote que contém componentes escritos em Rust e requer ferramentas de compilação (GCC, make, etc.) que não estavam instaladas no ambiente.
3. **Falta de atualização do pip**: As ferramentas de build Python (`pip`, `setuptools`, `wheel`) podem estar desatualizadas na imagem base do GitHub Actions.


oram adicionados os seguintes passos antes da instalação do `nodejsscan`:

1. **Versão específica do Python**: Definido `python-version: "3.11"` para garantir compatibilidade estável.
2. **Instalação de dependências de build**: Adicionado passo para instalar `build-essential` (GCC, make, libc6-dev, etc.).
3. **Atualização das ferramentas Python**: Atualização do `pip`, `setuptools` e `wheel` antes da instalação.